### PR TITLE
Fix navigation order: move Login after Docs

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -244,23 +244,6 @@ export default function LandingPage() {
               Forum
             </button>
             <button
-              onClick={() => router.push('/login')}
-              style={{
-                background: "none",
-                border: "none",
-                color: "rgba(255, 255, 255, 0.65)",
-                fontSize: "0.9375rem",
-                cursor: "pointer",
-                padding: "0.5rem 0",
-                fontWeight: "400",
-                transition: "color 0.2s"
-              }}
-              onMouseOver={(e) => e.currentTarget.style.color = "#ffffff"}
-              onMouseOut={(e) => e.currentTarget.style.color = "rgba(255, 255, 255, 0.65)"}
-            >
-              Login
-            </button>
-            <button
               onClick={() => router.push('/docs')}
               style={{
                 background: "none",
@@ -276,6 +259,23 @@ export default function LandingPage() {
               onMouseOut={(e) => e.currentTarget.style.color = "rgba(255, 255, 255, 0.65)"}
             >
               Docs
+            </button>
+            <button
+              onClick={() => router.push('/login')}
+              style={{
+                background: "none",
+                border: "none",
+                color: "rgba(255, 255, 255, 0.65)",
+                fontSize: "0.9375rem",
+                cursor: "pointer",
+                padding: "0.5rem 0",
+                fontWeight: "400",
+                transition: "color 0.2s"
+              }}
+              onMouseOver={(e) => e.currentTarget.style.color = "#ffffff"}
+              onMouseOut={(e) => e.currentTarget.style.color = "rgba(255, 255, 255, 0.65)"}
+            >
+              Login
             </button>
             <button
               onClick={() => router.push('/register')}
@@ -410,24 +410,6 @@ export default function LandingPage() {
           </button>
           <button
             onClick={() => {
-              router.push('/login');
-              setMobileMenuOpen(false);
-            }}
-            style={{
-              background: "none",
-              border: "none",
-              color: "rgba(255, 255, 255, 0.7)",
-              fontSize: "1.125rem",
-              cursor: "pointer",
-              padding: "1rem 0",
-              textAlign: "left",
-              transition: "color 0.2s"
-            }}
-          >
-            Login
-          </button>
-          <button
-            onClick={() => {
               router.push('/docs');
               setMobileMenuOpen(false);
             }}
@@ -443,6 +425,24 @@ export default function LandingPage() {
             }}
           >
             Docs
+          </button>
+          <button
+            onClick={() => {
+              router.push('/login');
+              setMobileMenuOpen(false);
+            }}
+            style={{
+              background: "none",
+              border: "none",
+              color: "rgba(255, 255, 255, 0.7)",
+              fontSize: "1.125rem",
+              cursor: "pointer",
+              padding: "1rem 0",
+              textAlign: "left",
+              transition: "color 0.2s"
+            }}
+          >
+            Login
           </button>
           <button
             onClick={() => {


### PR DESCRIPTION
## Summary
Fixed navigation order to place Login between Docs and Get Started for better navigation flow.

## Changes Made
- Updated desktop navigation: Forum -> Docs -> Login -> Get Started
- Updated mobile navigation: Forum -> Docs -> Login -> Get Started

## Navigation Flow
**Before:** FAQ -> Forum -> Login -> Docs -> Get Started
**After:** FAQ -> Forum -> Docs -> Login -> Get Started

## Files Changed
- app/page.jsx - Reordered navigation buttons in both desktop and mobile menus

## Testing
- Verified navigation order on desktop
- Verified navigation order on mobile
- All links work correctly
- No styling or functionality changes