### PR TITLE
Add scroll-based border to navigation (Issue #56)

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -17,6 +17,7 @@ export default function LandingPage() {
   const [feedbackError, setFeedbackError] = useState('');
   const [expandedFaq, setExpandedFaq] = useState(null);
   const [hoveredFaq, setHoveredFaq] = useState(null);
+  const [isScrolled, setIsScrolled] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [waitlistEmail, setWaitlistEmail] = useState('');
   const [waitlistSubmitting, setWaitlistSubmitting] = useState(false);
@@ -67,6 +68,16 @@ export default function LandingPage() {
     if (hasSeenIntro) {
       setShowIntro(false);
     }
+  }, []);
+
+  // Track scroll position for navigation border
+  useEffect(() => {
+    const handleScroll = () => {
+      setIsScrolled(window.scrollY > 50);
+    };
+
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
   const handleSplashComplete = () => {
@@ -169,7 +180,8 @@ export default function LandingPage() {
         zIndex: 50,
         backgroundColor: theme.navBackground,
         backdropFilter: "blur(10px)",
-        borderBottom: `1px solid ${theme.border}`,
+        borderBottom: isScrolled ? '1px solid rgba(0, 0, 0, 0.12)' : '1px solid transparent',
+        transition: 'border-color 0.2s ease',
         padding: "1rem 2rem",
       }}>
         <div style={{


### PR DESCRIPTION
Adds a dynamic border to the navigation bar that appears when the user scrolls down the page.

## Changes
- Added scroll state tracking (`isScrolled`)
- Implemented scroll event listener with 50px threshold
- Made navigation border conditional based on scroll position
- Added smooth 0.2s transition for border appearance
- Proper cleanup of scroll event listener on unmount

## Behavior
- **At page top (0-50px):** No visible border (transparent) for clean look
- **After scrolling (>50px):** Border fades in smoothly (rgba(0, 0, 0, 0.12))
- **Scrolling back up:** Border fades out when reaching top
- **All screen sizes:** Works consistently on desktop, tablet, and mobile

## Benefits
- Clean, minimal look when page first loads
- Clear visual separation between nav and content when scrolling
- Smooth transition enhances user experience
- Lightweight implementation with proper cleanup

Closes #56