### PR TITLE
feat: replace email/password auth with Google OAuth sign-in

### DIFF
--- a/app/api/auth/google/callback/route.js
+++ b/app/api/auth/google/callback/route.js
@@ -1,0 +1,150 @@
+import { NextResponse } from 'next/server';
+import { createSession, setSessionCookie } from '../../../../../lib/auth/session';
+import dbConnect from '../../../../../lib/db/connect';
+import User from '../../../../../lib/db/models/User';
+
+async function exchangeCodeForTokens(code, redirectUri) {
+  const response = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      code,
+      client_id: process.env.GOOGLE_CLIENT_ID,
+      client_secret: process.env.GOOGLE_CLIENT_SECRET,
+      redirect_uri: redirectUri,
+      grant_type: 'authorization_code',
+    }),
+  });
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(`Token exchange failed: ${error.error_description || error.error}`);
+  }
+
+  return response.json();
+}
+
+async function getGoogleUserInfo(accessToken) {
+  const response = await fetch('https://www.googleapis.com/oauth2/v2/userinfo', {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch user info from Google');
+  }
+
+  return response.json();
+}
+
+export async function GET(request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const code = searchParams.get('code');
+    const stateParam = searchParams.get('state');
+    const error = searchParams.get('error');
+
+    // User denied access or error occurred
+    if (error) {
+      return NextResponse.redirect(new URL('/login?error=oauth_denied', request.url));
+    }
+
+    if (!code || !stateParam) {
+      return NextResponse.redirect(new URL('/login?error=oauth_error', request.url));
+    }
+
+    // Verify CSRF state
+    const stateCookie = request.cookies.get('google_oauth_state')?.value;
+    let mode = 'login';
+
+    try {
+      const stateData = JSON.parse(Buffer.from(stateParam, 'base64url').toString());
+      mode = stateData.mode || 'login';
+
+      if (!stateCookie || stateCookie !== stateData.token) {
+        return NextResponse.redirect(new URL('/login?error=oauth_error', request.url));
+      }
+    } catch {
+      return NextResponse.redirect(new URL('/login?error=oauth_error', request.url));
+    }
+
+    // Exchange code for tokens
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+    const redirectUri = `${appUrl}/api/auth/google/callback`;
+    const tokens = await exchangeCodeForTokens(code, redirectUri);
+
+    // Get user info from Google
+    const googleUser = await getGoogleUserInfo(tokens.access_token);
+
+    if (!googleUser.email) {
+      return NextResponse.redirect(new URL(`/${mode === 'register' ? 'register' : 'login'}?error=no_email`, request.url));
+    }
+
+    // Validate @gmail.com
+    if (!googleUser.email.toLowerCase().endsWith('@gmail.com')) {
+      const redirectPath = mode === 'register' ? '/register' : '/login';
+      return NextResponse.redirect(new URL(`${redirectPath}?error=gmail_only`, request.url));
+    }
+
+    await dbConnect();
+
+    if (mode === 'register') {
+      // REGISTER MODE: Check if user already exists
+      const existingUser = await User.findOne({ email: googleUser.email.toLowerCase() });
+      if (existingUser) {
+        return NextResponse.redirect(new URL('/login?error=already_exists', request.url));
+      }
+
+      // Redirect to register page with Google data to collect org name
+      const googleData = Buffer.from(JSON.stringify({
+        email: googleUser.email,
+        name: googleUser.name,
+        googleId: googleUser.id,
+      })).toString('base64url');
+
+      const response = NextResponse.redirect(new URL(`/register?step=org&data=${googleData}`, request.url));
+      // Clear the state cookie
+      response.cookies.delete('google_oauth_state');
+      return response;
+
+    } else {
+      // LOGIN MODE: Find existing user
+      const user = await User.findOne({
+        $or: [
+          { email: googleUser.email.toLowerCase() },
+          { secondaryEmail: googleUser.email.toLowerCase() },
+        ],
+      });
+
+      if (!user) {
+        const response = NextResponse.redirect(new URL('/login?error=no_account', request.url));
+        response.cookies.delete('google_oauth_state');
+        return response;
+      }
+
+      // Link Google ID if not already linked
+      if (!user.googleId) {
+        user.googleId = googleUser.id;
+        await user.save();
+      }
+
+      // Mark email as verified (they verified through Google)
+      if (!user.emailVerified) {
+        user.emailVerified = true;
+        await user.save();
+      }
+
+      // Create session
+      const session = await createSession(user._id.toString());
+      await setSessionCookie(session.token, session.expiresAt);
+
+      // Redirect based on role
+      const redirectUrl = user.role === 'admin' ? '/admin' : '/dashboard';
+      const response = NextResponse.redirect(new URL(redirectUrl, request.url));
+      response.cookies.delete('google_oauth_state');
+      return response;
+    }
+  } catch (error) {
+    console.error('Google OAuth callback error:', error);
+    return NextResponse.redirect(new URL('/login?error=oauth_error', request.url));
+  }
+}

--- a/app/api/auth/google/register/route.js
+++ b/app/api/auth/google/register/route.js
@@ -1,0 +1,104 @@
+import { NextResponse } from 'next/server';
+import { createSession, setSessionCookie } from '../../../../../lib/auth/session';
+import dbConnect from '../../../../../lib/db/connect';
+import User from '../../../../../lib/db/models/User';
+import { rateLimit } from '../../../../../lib/utils/rateLimiter';
+
+export async function POST(request) {
+  try {
+    const { email, name, googleId, organizationName } = await request.json();
+
+    // Validation
+    if (!email || !name || !googleId || !organizationName) {
+      return NextResponse.json(
+        { error: 'All fields are required' },
+        { status: 400 }
+      );
+    }
+
+    // Validate @gmail.com
+    if (!email.toLowerCase().endsWith('@gmail.com')) {
+      return NextResponse.json(
+        { error: 'Only Gmail accounts are allowed' },
+        { status: 400 }
+      );
+    }
+
+    // Rate limiting: 3 registration attempts per IP per hour
+    const forwarded = request.headers.get('x-forwarded-for');
+    const ip = forwarded ? forwarded.split(',')[0] : 'unknown';
+    const rateLimitKey = `google-register:${ip}`;
+    const rateLimitResult = await rateLimit(rateLimitKey, 3, 60 * 60 * 1000);
+
+    if (!rateLimitResult.allowed) {
+      return NextResponse.json(
+        { error: 'Too many registration attempts. Please try again later.' },
+        { status: 429, headers: rateLimitResult.headers }
+      );
+    }
+
+    await dbConnect();
+
+    // Normalize organization name
+    const normalizedOrgName = organizationName.toLowerCase().trim();
+
+    // Check if email already exists
+    const existingUser = await User.findOne({ email: email.toLowerCase() });
+    if (existingUser) {
+      return NextResponse.json(
+        { error: 'Email already registered. Please sign in instead.' },
+        { status: 400 }
+      );
+    }
+
+    // Check if there's already a primary admin for this org
+    const existingPrimaryAdmin = await User.findOne({
+      role: 'admin',
+      adminType: 'primary',
+      organizationName: normalizedOrgName,
+    });
+
+    if (existingPrimaryAdmin) {
+      return NextResponse.json(
+        { error: 'Primary admin already exists for this organization. Please use a different organization name or contact the admin for an invite.' },
+        { status: 403 }
+      );
+    }
+
+    // Create primary admin user with Google ID (no password)
+    const user = await User.create({
+      email: email.toLowerCase(),
+      name,
+      googleId,
+      role: 'admin',
+      adminType: 'primary',
+      organizationName: normalizedOrgName,
+      emailVerified: true, // Verified through Google
+    });
+
+    // Create session and log them in
+    const session = await createSession(user._id.toString());
+    await setSessionCookie(session.token, session.expiresAt);
+
+    return NextResponse.json({
+      success: true,
+      message: 'Registration successful!',
+      redirectUrl: '/admin',
+    });
+  } catch (error) {
+    console.error('Google registration error:', error);
+
+    if (error.code === 11000) {
+      const field = Object.keys(error.keyPattern || {})[0];
+      return NextResponse.json(
+        { error: `${field === 'email' ? 'Email' : 'This value'} is already registered` },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json(
+      { error: 'Registration failed. Please try again.' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/auth/google/route.js
+++ b/app/api/auth/google/route.js
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server';
+import crypto from 'crypto';
+
+export async function GET(request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const mode = searchParams.get('mode') || 'login'; // 'login' or 'register'
+
+    const clientId = process.env.GOOGLE_CLIENT_ID;
+    if (!clientId) {
+      return NextResponse.json(
+        { error: 'Google OAuth is not configured' },
+        { status: 500 }
+      );
+    }
+
+    // Generate CSRF state token
+    const state = crypto.randomBytes(32).toString('hex');
+    const stateData = JSON.stringify({ token: state, mode });
+    const encodedState = Buffer.from(stateData).toString('base64url');
+
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+    const redirectUri = `${appUrl}/api/auth/google/callback`;
+
+    const params = new URLSearchParams({
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      response_type: 'code',
+      scope: 'openid email profile',
+      state: encodedState,
+      access_type: 'offline',
+      prompt: 'select_account',
+    });
+
+    const googleAuthUrl = `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`;
+
+    // Set state cookie for CSRF verification
+    const response = NextResponse.redirect(googleAuthUrl);
+    response.cookies.set('google_oauth_state', state, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 600, // 10 minutes
+      path: '/',
+    });
+
+    return response;
+  } catch (error) {
+    console.error('Google OAuth initiation error:', error);
+    return NextResponse.redirect(new URL('/login?error=oauth_error', request.url));
+  }
+}

--- a/app/api/auth/invite-admin/route.js
+++ b/app/api/auth/invite-admin/route.js
@@ -42,6 +42,14 @@ export async function POST(request) {
     // Determine primary email (use first available)
     const primaryEmail = email?.trim() || secondaryEmail?.trim();
 
+    // Validate primary email is @gmail.com (required for Google sign-in)
+    if (!primaryEmail.toLowerCase().endsWith('@gmail.com')) {
+      return NextResponse.json(
+        { error: 'Only Gmail accounts (@gmail.com) are allowed. Users must sign in with Google.' },
+        { status: 400 }
+      );
+    }
+
     await dbConnect();
 
     // Get the current admin (to get organization name)

--- a/app/api/students/[id]/route.js
+++ b/app/api/students/[id]/route.js
@@ -19,6 +19,14 @@ export async function PUT(request, { params }) {
       );
     }
 
+    // Validate email is @gmail.com (required for Google sign-in)
+    if (!email.toLowerCase().trim().endsWith('@gmail.com')) {
+      return NextResponse.json(
+        { error: 'Only Gmail accounts (@gmail.com) are allowed. Users must sign in with Google.' },
+        { status: 400 }
+      );
+    }
+
     await dbConnect();
 
     // Get current admin's organization

--- a/app/api/students/route.js
+++ b/app/api/students/route.js
@@ -60,6 +60,14 @@ export async function POST(request) {
     // Determine primary email (use first available)
     const primaryEmail = email?.trim() || secondaryEmail?.trim();
 
+    // Validate primary email is @gmail.com (required for Google sign-in)
+    if (!primaryEmail.toLowerCase().endsWith('@gmail.com')) {
+      return NextResponse.json(
+        { error: 'Only Gmail accounts (@gmail.com) are allowed. Users must sign in with Google.' },
+        { status: 400 }
+      );
+    }
+
     await dbConnect();
 
     // Get current admin's organization

--- a/app/login/page.jsx
+++ b/app/login/page.jsx
@@ -1,180 +1,36 @@
 'use client';
 
-import { useState, useEffect, Suspense } from 'react';
+import { Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 
 function LoginForm() {
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [code, setCode] = useState('');
-  const [loading, setLoading] = useState(false);
-  const [message, setMessage] = useState('');
-  const [error, setError] = useState('');
-  const [codeSent, setCodeSent] = useState(false);
-  const [canResend, setCanResend] = useState(false);
-  const [resendCountdown, setResendCountdown] = useState(0);
-  const [usePasswordLogin, setUsePasswordLogin] = useState(true);
-
   const searchParams = useSearchParams();
   const urlError = searchParams.get('error');
 
-  // Countdown timer for resend button
-  useEffect(() => {
-    if (resendCountdown > 0) {
-      const timer = setTimeout(() => {
-        setResendCountdown(resendCountdown - 1);
-      }, 1000);
-      return () => clearTimeout(timer);
-    } else if (resendCountdown === 0 && codeSent) {
-      setCanResend(true);
-    }
-  }, [resendCountdown, codeSent]);
-
-  const startResendCountdown = () => {
-    setCanResend(false);
-    setResendCountdown(90); // 90 seconds to match rate limit
-  };
-
-  const handlePasswordLogin = async (e) => {
-    e.preventDefault();
-    setLoading(true);
-    setError('');
-    setMessage('');
-
-    try {
-      const res = await fetch('/api/auth/login', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password }),
-      });
-
-      const data = await res.json();
-
-      if (!res.ok) {
-        setError(data.error || 'Login failed');
-        setLoading(false);
-        return;
-      }
-
-      // Check if 2FA is required
-      if (data.requires2FA) {
-        window.location.href = `/verify-2fa?userId=${data.userId}`;
-        return;
-      }
-
-      // Login successful - redirect based on role
-      if (data.redirectUrl) {
-        window.location.href = data.redirectUrl;
-      }
-
-    } catch (err) {
-      setError('Something went wrong. Please try again.');
-      setLoading(false);
+  const getErrorMessage = (error) => {
+    switch (error) {
+      case 'oauth_denied':
+        return 'Google sign-in was cancelled. Please try again.';
+      case 'oauth_error':
+        return 'Something went wrong with Google sign-in. Please try again.';
+      case 'no_account':
+        return 'No account found with this email. Contact your organization admin.';
+      case 'already_exists':
+        return 'An account with this email already exists. Please sign in instead.';
+      case 'gmail_only':
+        return 'Only Gmail accounts (@gmail.com) are supported. Please use a Gmail account.';
+      case 'no_email':
+        return 'Could not retrieve your email from Google. Please try again.';
+      default:
+        return error ? 'An error occurred. Please try again.' : null;
     }
   };
 
-  const handleRequestCode = async (e) => {
-    e.preventDefault();
-    setLoading(true);
-    setError('');
-    setMessage('');
+  const errorMessage = getErrorMessage(urlError);
 
-    try {
-      const res = await fetch('/api/auth/request-link', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email }),
-      });
-
-      const data = await res.json();
-
-      if (!res.ok) {
-        setError(data.error || 'Failed to send code');
-        setLoading(false);
-        return;
-      }
-
-      setCodeSent(true);
-      setMessage('Verification code sent! Check your email.');
-      setLoading(false);
-      startResendCountdown();
-
-    } catch (err) {
-      setError('Something went wrong. Please try again.');
-      setLoading(false);
-    }
-  };
-
-  const handleVerifyCode = async (e) => {
-    e.preventDefault();
-    setLoading(true);
-    setError('');
-    setMessage('');
-
-    try {
-      const res = await fetch('/api/auth/verify-code', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, code }),
-      });
-
-      const data = await res.json();
-
-      if (!res.ok) {
-        setError(data.error || 'Invalid verification code');
-        setLoading(false);
-        return;
-      }
-
-      // Login successful - redirect based on role
-      if (data.redirectUrl) {
-        window.location.href = data.redirectUrl;
-      }
-
-    } catch (err) {
-      setError('Something went wrong. Please try again.');
-      setLoading(false);
-    }
-  };
-
-  const handleBackToEmail = () => {
-    setCodeSent(false);
-    setCode('');
-    setError('');
-    setMessage('');
-    setCanResend(false);
-    setResendCountdown(0);
-  };
-
-  const handleResendCode = async () => {
-    setError('');
-    setMessage('');
-    setLoading(true);
-
-    try {
-      const res = await fetch('/api/auth/request-link', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email }),
-      });
-
-      const data = await res.json();
-
-      if (!res.ok) {
-        setError(data.error || 'Failed to resend code');
-        setLoading(false);
-        return;
-      }
-
-      setMessage('New verification code sent!');
-      setLoading(false);
-      startResendCountdown();
-
-    } catch (err) {
-      setError('Failed to resend code. Please try again.');
-      setLoading(false);
-    }
+  const handleGoogleSignIn = () => {
+    window.location.href = '/api/auth/google?mode=login';
   };
 
   return (
@@ -233,8 +89,6 @@ function LoginForm() {
             Schedule Builder Team
           </p>
         </div>
-
-        {/* Responsive styles will be added via <style> tag below */}
       </div>
 
       {/* RIGHT PANEL - White */}
@@ -243,664 +97,148 @@ function LoginForm() {
         backgroundColor: '#ffffff',
         padding: '2rem 3rem',
         display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        overflowY: 'auto'
+        flexDirection: 'column',
+        position: 'relative'
       }}
       className="right-panel">
-        <div style={{ maxWidth: '420px', width: '100%' }}>
 
-          {/* Header */}
-          <div style={{ marginBottom: '1.5rem' }}>
-            <h2 style={{
-              fontSize: '28px',
-              fontWeight: '600',
+        {/* Sign Up link top right */}
+        <div style={{
+          display: 'flex',
+          justifyContent: 'flex-end',
+          marginBottom: '2rem'
+        }}>
+          <Link
+            href="/register"
+            style={{
               color: 'rgba(0, 0, 0, 0.87)',
-              marginBottom: '0.5rem',
+              fontSize: '0.9375rem',
+              textDecoration: 'none',
+              fontWeight: '400'
+            }}
+            onMouseOver={(e) => e.currentTarget.style.color = '#14b8a6'}
+            onMouseOut={(e) => e.currentTarget.style.color = 'rgba(0, 0, 0, 0.87)'}
+          >
+            Sign Up
+          </Link>
+        </div>
+
+        {/* Centered content */}
+        <div style={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center'
+        }}>
+          <div style={{ maxWidth: '420px', width: '100%' }}>
+
+            {/* Header */}
+            <div style={{ marginBottom: '2rem', textAlign: 'center' }}>
+              <h2 style={{
+                fontSize: '28px',
+                fontWeight: '600',
+                color: 'rgba(0, 0, 0, 0.87)',
+                margin: 0
+              }}>
+                Sign in to your account
+              </h2>
+            </div>
+
+            {/* Error Message */}
+            {errorMessage && (
+              <div style={{
+                padding: '1rem 1.25rem',
+                backgroundColor: 'rgba(239, 68, 68, 0.1)',
+                border: '1px solid rgba(239, 68, 68, 0.3)',
+                borderRadius: '8px',
+                marginBottom: '1.5rem'
+              }}>
+                <p style={{
+                  color: '#dc2626',
+                  fontSize: '0.9375rem',
+                  margin: 0,
+                  fontWeight: '400',
+                  textAlign: 'center'
+                }}>
+                  {errorMessage}
+                </p>
+              </div>
+            )}
+
+            {/* Continue with Google Button */}
+            <button
+              onClick={handleGoogleSignIn}
+              style={{
+                width: '100%',
+                padding: '0.875rem 1.5rem',
+                backgroundColor: '#ffffff',
+                color: 'rgba(0, 0, 0, 0.87)',
+                border: '1px solid rgba(0, 0, 0, 0.2)',
+                borderRadius: '8px',
+                fontSize: '16px',
+                fontWeight: '500',
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: '0.75rem',
+                transition: 'all 0.2s',
+                marginBottom: '1.5rem'
+              }}
+              onMouseOver={(e) => {
+                e.currentTarget.style.backgroundColor = 'rgba(0, 0, 0, 0.02)';
+                e.currentTarget.style.borderColor = 'rgba(0, 0, 0, 0.3)';
+              }}
+              onMouseOut={(e) => {
+                e.currentTarget.style.backgroundColor = '#ffffff';
+                e.currentTarget.style.borderColor = 'rgba(0, 0, 0, 0.2)';
+              }}
+            >
+              {/* Google Icon */}
+              <svg width="20" height="20" viewBox="0 0 24 24">
+                <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4"/>
+                <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+                <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
+                <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+              </svg>
+              Continue with Google
+            </button>
+
+            {/* Terms of Service */}
+            <p style={{
+              fontSize: '0.8125rem',
+              color: 'rgba(0, 0, 0, 0.45)',
+              textAlign: 'center',
+              lineHeight: '1.6',
               margin: 0
             }}>
-              {codeSent ? 'Enter verification code' : 'Sign in to your account'}
-            </h2>
-            <p style={{
-              fontSize: '15px',
-              color: 'rgba(0, 0, 0, 0.5)',
-              fontWeight: '300',
-              margin: '0.25rem 0 0 0'
-            }}>
-              {!codeSent && 'Welcome back to Schedule Builder'}
+              By clicking continue, you agree to our{' '}
+              <a
+                href="https://schedule-builder-docs.vercel.app/legal/terms.html"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  color: 'rgba(0, 0, 0, 0.6)',
+                  textDecoration: 'underline'
+                }}
+              >
+                Terms of Service
+              </a>
+              {' '}and{' '}
+              <a
+                href="https://schedule-builder-docs.vercel.app/legal/privacy.html"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  color: 'rgba(0, 0, 0, 0.6)',
+                  textDecoration: 'underline'
+                }}
+              >
+                Privacy Policy
+              </a>.
             </p>
+
           </div>
-
-          {/* URL Error */}
-          {urlError && (
-            <div style={{
-              padding: '1rem 1.25rem',
-              backgroundColor: 'rgba(239, 68, 68, 0.1)',
-              border: '1px solid rgba(239, 68, 68, 0.3)',
-              borderRadius: '8px',
-              marginBottom: '1.5rem'
-            }}>
-              <p style={{
-                color: '#dc2626',
-                fontSize: '0.9375rem',
-                margin: 0,
-                fontWeight: '400'
-              }}>
-                {urlError === 'invalid_token' && 'Invalid login link'}
-                {urlError === 'expired_or_invalid' && 'Login link expired or invalid'}
-                {urlError === 'server_error' && 'Server error. Please try again.'}
-              </p>
-            </div>
-          )}
-
-          {/* Error Message */}
-          {error && (
-            <div style={{
-              padding: '1rem 1.25rem',
-              backgroundColor: 'rgba(239, 68, 68, 0.1)',
-              border: '1px solid rgba(239, 68, 68, 0.3)',
-              borderRadius: '8px',
-              marginBottom: '1.5rem'
-            }}>
-              <p style={{
-                color: '#dc2626',
-                fontSize: '0.9375rem',
-                margin: 0,
-                fontWeight: '400'
-              }}>
-                {error}
-              </p>
-            </div>
-          )}
-
-          {/* Success Message */}
-          {message && (
-            <div style={{
-              padding: '1rem 1.25rem',
-              backgroundColor: 'rgba(20, 184, 166, 0.1)',
-              border: '1px solid rgba(20, 184, 166, 0.3)',
-              borderRadius: '8px',
-              marginBottom: '1.5rem'
-            }}>
-              <p style={{
-                color: '#14b8a6',
-                fontSize: '0.9375rem',
-                margin: 0,
-                fontWeight: '400'
-              }}>
-                {message}
-              </p>
-            </div>
-          )}
-
-          {/* Password Login Step */}
-          {!codeSent && usePasswordLogin && (
-            <form onSubmit={handlePasswordLogin}>
-              <div style={{ marginBottom: '1.5rem' }}>
-                <label style={{
-                  display: 'block',
-                  fontSize: '14px',
-                  fontWeight: '500',
-                  color: 'rgba(0, 0, 0, 0.65)',
-                  marginBottom: '0.5rem'
-                }}>
-                  Email Address
-                </label>
-                <input
-                  type="email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  required
-                  disabled={loading}
-                  placeholder="you@example.com"
-                  style={{
-                    width: '100%',
-                    padding: '0.875rem 1rem',
-                    backgroundColor: '#ffffff',
-                    border: '1px solid rgba(0, 0, 0, 0.2)',
-                    borderRadius: '8px',
-                    fontSize: '0.9375rem',
-                    color: 'rgba(0, 0, 0, 0.87)',
-                    outline: 'none',
-                    fontWeight: '400',
-                    transition: 'all 0.2s',
-                    boxSizing: 'border-box'
-                  }}
-                  onFocus={(e) => {
-                    e.currentTarget.style.borderColor = '#14b8a6';
-                    e.currentTarget.style.boxShadow = '0 0 0 3px rgba(20, 184, 166, 0.1)';
-                  }}
-                  onBlur={(e) => {
-                    e.currentTarget.style.borderColor = 'rgba(0, 0, 0, 0.2)';
-                    e.currentTarget.style.boxShadow = 'none';
-                  }}
-                />
-              </div>
-
-              <div style={{ marginBottom: '1rem' }}>
-                <label style={{
-                  display: 'block',
-                  fontSize: '14px',
-                  fontWeight: '500',
-                  color: 'rgba(0, 0, 0, 0.65)',
-                  marginBottom: '0.5rem'
-                }}>
-                  Password
-                </label>
-                <input
-                  type="password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  required
-                  disabled={loading}
-                  placeholder="Enter your password"
-                  style={{
-                    width: '100%',
-                    padding: '0.875rem 1rem',
-                    backgroundColor: '#ffffff',
-                    border: '1px solid rgba(0, 0, 0, 0.2)',
-                    borderRadius: '8px',
-                    fontSize: '0.9375rem',
-                    color: 'rgba(0, 0, 0, 0.87)',
-                    outline: 'none',
-                    fontWeight: '400',
-                    transition: 'all 0.2s',
-                    boxSizing: 'border-box'
-                  }}
-                  onFocus={(e) => {
-                    e.currentTarget.style.borderColor = '#14b8a6';
-                    e.currentTarget.style.boxShadow = '0 0 0 3px rgba(20, 184, 166, 0.1)';
-                  }}
-                  onBlur={(e) => {
-                    e.currentTarget.style.borderColor = 'rgba(0, 0, 0, 0.2)';
-                    e.currentTarget.style.boxShadow = 'none';
-                  }}
-                />
-              </div>
-
-              {/* Forgot Password Link */}
-              <div style={{
-                textAlign: 'right',
-                marginBottom: '1.5rem'
-              }}>
-                <Link
-                  href="/forgot-password"
-                  style={{
-                    fontSize: '0.875rem',
-                    color: '#14b8a6',
-                    textDecoration: 'none',
-                    fontWeight: '400',
-                    transition: 'color 0.2s'
-                  }}
-                  onMouseOver={(e) => e.currentTarget.style.color = '#0d9488'}
-                  onMouseOut={(e) => e.currentTarget.style.color = '#14b8a6'}
-                >
-                  Forgot Password?
-                </Link>
-              </div>
-
-              <button
-                type="submit"
-                disabled={loading}
-                style={{
-                  width: '100%',
-                  padding: '0.875rem 1.5rem',
-                  backgroundColor: loading ? 'rgba(20, 184, 166, 0.5)' : '#14b8a6',
-                  color: '#ffffff',
-                  border: 'none',
-                  borderRadius: '8px',
-                  fontSize: '16px',
-                  fontWeight: '500',
-                  cursor: loading ? 'not-allowed' : 'pointer',
-                  marginBottom: '1.5rem',
-                  transition: 'all 0.2s'
-                }}
-                onMouseOver={(e) => {
-                  if (!loading) e.currentTarget.style.backgroundColor = '#0d9488';
-                }}
-                onMouseOut={(e) => {
-                  if (!loading) e.currentTarget.style.backgroundColor = '#14b8a6';
-                }}
-              >
-                {loading ? 'Signing in...' : 'Sign In'}
-              </button>
-
-              {/* Alternative Login Option */}
-              <div style={{
-                textAlign: 'center',
-                marginBottom: '1.5rem'
-              }}>
-                <button
-                  type="button"
-                  onClick={() => setUsePasswordLogin(false)}
-                  style={{
-                    background: 'none',
-                    border: 'none',
-                    color: '#14b8a6',
-                    fontSize: '0.875rem',
-                    cursor: 'pointer',
-                    padding: 0,
-                    textDecoration: 'none',
-                    fontWeight: '400'
-                  }}
-                  onMouseOver={(e) => e.currentTarget.style.textDecoration = 'underline'}
-                  onMouseOut={(e) => e.currentTarget.style.textDecoration = 'none'}
-                >
-                  Use verification code instead
-                </button>
-              </div>
-
-              {/* Register/Set Password Links */}
-              <div style={{
-                textAlign: 'center',
-                paddingTop: '1.5rem',
-                borderTop: '1px solid rgba(0, 0, 0, 0.1)'
-              }}>
-                <p style={{
-                  fontSize: '0.875rem',
-                  color: 'rgba(0, 0, 0, 0.5)',
-                  marginBottom: '0.75rem',
-                  fontWeight: '400'
-                }}>
-                  First time here?
-                </p>
-                <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
-                  <Link
-                    href="/set-password"
-                    style={{
-                      color: '#14b8a6',
-                      fontSize: '0.9375rem',
-                      textDecoration: 'none',
-                      fontWeight: '400'
-                    }}
-                    onMouseOver={(e) => e.currentTarget.style.textDecoration = 'underline'}
-                    onMouseOut={(e) => e.currentTarget.style.textDecoration = 'none'}
-                  >
-                    Set your password (Students)
-                  </Link>
-                  <Link
-                    href="/register"
-                    style={{
-                      color: 'rgba(0, 0, 0, 0.5)',
-                      fontSize: '0.875rem',
-                      textDecoration: 'none',
-                      fontWeight: '400'
-                    }}
-                    onMouseOver={(e) => e.currentTarget.style.color = 'rgba(0, 0, 0, 0.7)'}
-                    onMouseOut={(e) => e.currentTarget.style.color = 'rgba(0, 0, 0, 0.5)'}
-                  >
-                    Register as Admin
-                  </Link>
-                </div>
-              </div>
-            </form>
-          )}
-
-          {/* Email Step for Verification Code */}
-          {!codeSent && !usePasswordLogin && (
-            <form onSubmit={handleRequestCode}>
-              <div style={{ marginBottom: '2rem' }}>
-                <label style={{
-                  display: 'block',
-                  fontSize: '14px',
-                  fontWeight: '500',
-                  color: 'rgba(0, 0, 0, 0.65)',
-                  marginBottom: '0.5rem'
-                }}>
-                  Email Address
-                </label>
-                <input
-                  type="email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  required
-                  disabled={loading}
-                  placeholder="you@example.com"
-                  style={{
-                    width: '100%',
-                    padding: '0.875rem 1rem',
-                    backgroundColor: '#ffffff',
-                    border: '1px solid rgba(0, 0, 0, 0.2)',
-                    borderRadius: '8px',
-                    fontSize: '0.9375rem',
-                    color: 'rgba(0, 0, 0, 0.87)',
-                    outline: 'none',
-                    fontWeight: '400',
-                    transition: 'all 0.2s',
-                    boxSizing: 'border-box'
-                  }}
-                  onFocus={(e) => {
-                    e.currentTarget.style.borderColor = '#14b8a6';
-                    e.currentTarget.style.boxShadow = '0 0 0 3px rgba(20, 184, 166, 0.1)';
-                  }}
-                  onBlur={(e) => {
-                    e.currentTarget.style.borderColor = 'rgba(0, 0, 0, 0.2)';
-                    e.currentTarget.style.boxShadow = 'none';
-                  }}
-                />
-              </div>
-
-              <button
-                type="submit"
-                disabled={loading}
-                style={{
-                  width: '100%',
-                  padding: '0.875rem 1.5rem',
-                  backgroundColor: loading ? 'rgba(20, 184, 166, 0.5)' : '#14b8a6',
-                  color: '#ffffff',
-                  border: 'none',
-                  borderRadius: '8px',
-                  fontSize: '16px',
-                  fontWeight: '500',
-                  cursor: loading ? 'not-allowed' : 'pointer',
-                  marginBottom: '1.5rem',
-                  transition: 'all 0.2s'
-                }}
-                onMouseOver={(e) => {
-                  if (!loading) e.currentTarget.style.backgroundColor = '#0d9488';
-                }}
-                onMouseOut={(e) => {
-                  if (!loading) e.currentTarget.style.backgroundColor = '#14b8a6';
-                }}
-              >
-                {loading ? 'Sending code...' : 'Send Verification Code'}
-              </button>
-
-              {/* Info */}
-              <div style={{
-                padding: '1rem 1.25rem',
-                backgroundColor: 'rgba(20, 184, 166, 0.05)',
-                border: '1px solid rgba(20, 184, 166, 0.2)',
-                borderRadius: '8px',
-                marginBottom: '1rem'
-              }}>
-                <p style={{
-                  color: 'rgba(0, 0, 0, 0.6)',
-                  fontSize: '0.875rem',
-                  margin: 0,
-                  lineHeight: '1.6',
-                  fontWeight: '400'
-                }}>
-                  We'll send a 6-digit code to your email. Code expires in 10 minutes.
-                </p>
-              </div>
-
-              {/* School Email Warning */}
-              <div style={{
-                padding: '1rem 1.25rem',
-                backgroundColor: 'rgba(239, 68, 68, 0.05)',
-                border: '1px solid rgba(239, 68, 68, 0.2)',
-                borderRadius: '8px',
-                marginBottom: '1.5rem'
-              }}>
-                <p style={{
-                  color: 'rgba(220, 38, 38, 0.8)',
-                  fontSize: '0.875rem',
-                  margin: 0,
-                  lineHeight: '1.6',
-                  fontWeight: '400'
-                }}>
-                  Note: Accounts with school/work email addresses may not receive email notifications due to spam filtering. Please use password login instead.
-                </p>
-              </div>
-
-              {/* Alternative Login Option */}
-              <div style={{
-                textAlign: 'center',
-                marginBottom: '1.5rem'
-              }}>
-                <button
-                  type="button"
-                  onClick={() => setUsePasswordLogin(true)}
-                  style={{
-                    background: 'none',
-                    border: 'none',
-                    color: '#14b8a6',
-                    fontSize: '0.875rem',
-                    cursor: 'pointer',
-                    padding: 0,
-                    textDecoration: 'none',
-                    fontWeight: '400'
-                  }}
-                  onMouseOver={(e) => e.currentTarget.style.textDecoration = 'underline'}
-                  onMouseOut={(e) => e.currentTarget.style.textDecoration = 'none'}
-                >
-                  Use password instead
-                </button>
-              </div>
-
-              {/* Register/Set Password Links */}
-              <div style={{
-                textAlign: 'center',
-                paddingTop: '1.5rem',
-                borderTop: '1px solid rgba(0, 0, 0, 0.1)'
-              }}>
-                <p style={{
-                  fontSize: '0.875rem',
-                  color: 'rgba(0, 0, 0, 0.5)',
-                  marginBottom: '0.75rem',
-                  fontWeight: '400'
-                }}>
-                  First time here?
-                </p>
-                <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
-                  <Link
-                    href="/set-password"
-                    style={{
-                      color: '#14b8a6',
-                      fontSize: '0.9375rem',
-                      textDecoration: 'none',
-                      fontWeight: '400'
-                    }}
-                    onMouseOver={(e) => e.currentTarget.style.textDecoration = 'underline'}
-                    onMouseOut={(e) => e.currentTarget.style.textDecoration = 'none'}
-                  >
-                    Set your password (Students)
-                  </Link>
-                  <Link
-                    href="/register"
-                    style={{
-                      color: 'rgba(0, 0, 0, 0.5)',
-                      fontSize: '0.875rem',
-                      textDecoration: 'none',
-                      fontWeight: '400'
-                    }}
-                    onMouseOver={(e) => e.currentTarget.style.color = 'rgba(0, 0, 0, 0.7)'}
-                    onMouseOut={(e) => e.currentTarget.style.color = 'rgba(0, 0, 0, 0.5)'}
-                  >
-                    Register as Admin
-                  </Link>
-                </div>
-              </div>
-            </form>
-          )}
-
-          {/* Verification Code Step */}
-          {codeSent && (
-            <form onSubmit={handleVerifyCode}>
-              {/* Email Display */}
-              <div style={{ marginBottom: '1.5rem' }}>
-                <p style={{
-                  fontSize: '0.875rem',
-                  color: 'rgba(0, 0, 0, 0.6)',
-                  margin: '0 0 0.5rem 0',
-                  fontWeight: '400'
-                }}>
-                  Signing in as: <strong style={{ color: '#14b8a6', fontWeight: '500' }}>{email}</strong>
-                </p>
-                <button
-                  type="button"
-                  onClick={handleBackToEmail}
-                  style={{
-                    background: 'none',
-                    border: 'none',
-                    color: '#14b8a6',
-                    fontSize: '0.875rem',
-                    cursor: 'pointer',
-                    padding: 0,
-                    textDecoration: 'none',
-                    fontWeight: '400'
-                  }}
-                  onMouseOver={(e) => e.currentTarget.style.textDecoration = 'underline'}
-                  onMouseOut={(e) => e.currentTarget.style.textDecoration = 'none'}
-                >
-                  Change email
-                </button>
-              </div>
-
-              {/* Code Input */}
-              <div style={{ marginBottom: '2rem' }}>
-                <label style={{
-                  display: 'block',
-                  fontSize: '14px',
-                  fontWeight: '500',
-                  color: 'rgba(0, 0, 0, 0.65)',
-                  marginBottom: '0.5rem'
-                }}>
-                  Verification Code
-                </label>
-                <input
-                  type="text"
-                  value={code}
-                  onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
-                  required
-                  disabled={loading}
-                  placeholder="000000"
-                  maxLength={6}
-                  autoComplete="off"
-                  autoFocus
-                  style={{
-                    width: '100%',
-                    padding: '0.875rem 1rem',
-                    backgroundColor: '#ffffff',
-                    border: '1px solid rgba(0, 0, 0, 0.2)',
-                    borderRadius: '8px',
-                    fontSize: '1.5rem',
-                    color: 'rgba(0, 0, 0, 0.87)',
-                    outline: 'none',
-                    fontWeight: '400',
-                    transition: 'all 0.2s',
-                    letterSpacing: '0.5rem',
-                    textAlign: 'center',
-                    fontFamily: 'monospace',
-                    boxSizing: 'border-box'
-                  }}
-                  onFocus={(e) => {
-                    e.currentTarget.style.borderColor = '#14b8a6';
-                    e.currentTarget.style.boxShadow = '0 0 0 3px rgba(20, 184, 166, 0.1)';
-                  }}
-                  onBlur={(e) => {
-                    e.currentTarget.style.borderColor = 'rgba(0, 0, 0, 0.2)';
-                    e.currentTarget.style.boxShadow = 'none';
-                  }}
-                />
-              </div>
-
-              {/* Submit Button */}
-              <button
-                type="submit"
-                disabled={loading || code.length !== 6}
-                style={{
-                  width: '100%',
-                  padding: '0.875rem 1.5rem',
-                  backgroundColor: (loading || code.length !== 6) ? 'rgba(20, 184, 166, 0.5)' : '#14b8a6',
-                  color: '#ffffff',
-                  border: 'none',
-                  borderRadius: '8px',
-                  fontSize: '16px',
-                  fontWeight: '500',
-                  cursor: (loading || code.length !== 6) ? 'not-allowed' : 'pointer',
-                  marginBottom: '1.5rem',
-                  transition: 'all 0.2s'
-                }}
-                onMouseOver={(e) => {
-                  if (!loading && code.length === 6) e.currentTarget.style.backgroundColor = '#0d9488';
-                }}
-                onMouseOut={(e) => {
-                  if (!loading && code.length === 6) e.currentTarget.style.backgroundColor = '#14b8a6';
-                }}
-              >
-                {loading ? 'Verifying...' : 'Verify & Sign In'}
-              </button>
-
-              {/* Info */}
-              <div style={{
-                padding: '1rem 1.25rem',
-                backgroundColor: 'rgba(20, 184, 166, 0.05)',
-                border: '1px solid rgba(20, 184, 166, 0.2)',
-                borderRadius: '8px',
-                marginBottom: '1.5rem'
-              }}>
-                <p style={{
-                  color: 'rgba(0, 0, 0, 0.6)',
-                  fontSize: '0.875rem',
-                  margin: '0 0 0.5rem 0',
-                  lineHeight: '1.6',
-                  fontWeight: '400'
-                }}>
-                  Check your email for the 6-digit code. Code expires in 10 minutes.
-                </p>
-              </div>
-
-              {/* Resend */}
-              <div style={{
-                textAlign: 'center',
-                paddingTop: '1.5rem',
-                borderTop: '1px solid rgba(0, 0, 0, 0.1)'
-              }}>
-                {canResend ? (
-                  <button
-                    type="button"
-                    onClick={handleResendCode}
-                    disabled={loading}
-                    style={{
-                      background: 'none',
-                      border: 'none',
-                      color: '#14b8a6',
-                      fontSize: '0.9375rem',
-                      cursor: loading ? 'not-allowed' : 'pointer',
-                      padding: 0,
-                      textDecoration: 'none',
-                      fontWeight: '400'
-                    }}
-                    onMouseOver={(e) => {
-                      if (!loading) e.currentTarget.style.textDecoration = 'underline';
-                    }}
-                    onMouseOut={(e) => e.currentTarget.style.textDecoration = 'none'}
-                  >
-                    Resend verification code
-                  </button>
-                ) : (
-                  <p style={{
-                    fontSize: '0.875rem',
-                    color: 'rgba(0, 0, 0, 0.4)',
-                    margin: 0,
-                    fontWeight: '400'
-                  }}>
-                    Resend code in {resendCountdown}s
-                  </p>
-                )}
-              </div>
-            </form>
-          )}
-
-          {/* Footer */}
-          <div style={{ marginTop: '2rem', textAlign: 'center' }}>
-            <Link
-              href="/"
-              style={{
-                color: 'rgba(0, 0, 0, 0.4)',
-                fontSize: '0.875rem',
-                textDecoration: 'none',
-                fontWeight: '400'
-              }}
-              onMouseOver={(e) => e.currentTarget.style.color = 'rgba(0, 0, 0, 0.6)'}
-              onMouseOut={(e) => e.currentTarget.style.color = 'rgba(0, 0, 0, 0.4)'}
-            >
-              Back to home
-            </Link>
-          </div>
-
         </div>
       </div>
 

--- a/app/register/page.jsx
+++ b/app/register/page.jsx
@@ -1,56 +1,75 @@
 'use client';
 
-import { useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useState, useEffect, Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
-import { usePasswordValidation } from '@/lib/hooks/usePasswordValidation';
-import PasswordRequirementsDisplay from '@/components/auth/PasswordRequirementsDisplay';
 
-export default function RegisterPage() {
-  const router = useRouter();
-  const [formData, setFormData] = useState({
-    name: '',
-    email: '',
-    organizationName: '',
-    password: '',
-    confirmPassword: '',
-  });
+function RegisterForm() {
+  const searchParams = useSearchParams();
+  const step = searchParams.get('step');
+  const dataParam = searchParams.get('data');
+  const urlError = searchParams.get('error');
+
+  const [googleData, setGoogleData] = useState(null);
+  const [organizationName, setOrganizationName] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
-  const [success, setSuccess] = useState(false);
 
-  // Use password validation hook
-  const { validation: passwordValidation, isValid: isPasswordValid } = usePasswordValidation(formData.password);
+  // Parse Google data if returning from OAuth
+  useEffect(() => {
+    if (step === 'org' && dataParam) {
+      try {
+        const parsed = JSON.parse(Buffer.from(dataParam, 'base64url').toString());
+        if (parsed.email && parsed.name && parsed.googleId) {
+          setGoogleData(parsed);
+        } else {
+          setError('Invalid registration data. Please try again.');
+        }
+      } catch {
+        setError('Invalid registration data. Please try again.');
+      }
+    }
+  }, [step, dataParam]);
 
-  const handleChange = (e) => {
-    setFormData({
-      ...formData,
-      [e.target.name]: e.target.value,
-    });
+  const getErrorMessage = (err) => {
+    switch (err) {
+      case 'oauth_denied':
+        return 'Google sign-up was cancelled. Please try again.';
+      case 'oauth_error':
+        return 'Something went wrong with Google sign-up. Please try again.';
+      case 'already_exists':
+        return 'An account with this email already exists. Please sign in instead.';
+      case 'gmail_only':
+        return 'Only Gmail accounts (@gmail.com) are supported. Please use a Gmail account.';
+      case 'no_email':
+        return 'Could not retrieve your email from Google. Please try again.';
+      default:
+        return err ? 'An error occurred. Please try again.' : null;
+    }
   };
 
-  const handleSubmit = async (e) => {
+  const errorFromUrl = getErrorMessage(urlError);
+
+  const handleGoogleSignUp = () => {
+    window.location.href = '/api/auth/google?mode=register';
+  };
+
+  const handleSubmitOrg = async (e) => {
     e.preventDefault();
+    if (!googleData) return;
+
     setLoading(true);
     setError('');
-    setSuccess(false);
-
-    // Validate passwords match
-    if (formData.password !== formData.confirmPassword) {
-      setError('Passwords do not match');
-      setLoading(false);
-      return;
-    }
 
     try {
-      const res = await fetch('/api/auth/register', {
+      const res = await fetch('/api/auth/google/register', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          name: formData.name,
-          email: formData.email,
-          organizationName: formData.organizationName,
-          password: formData.password,
+          email: googleData.email,
+          name: googleData.name,
+          googleId: googleData.googleId,
+          organizationName,
         }),
       });
 
@@ -62,15 +81,18 @@ export default function RegisterPage() {
         return;
       }
 
-      // Registration successful - redirect to login
-      window.location.href = '/login';
-      setLoading(false);
-
-    } catch (err) {
+      // Registration successful - redirect to admin dashboard
+      if (data.redirectUrl) {
+        window.location.href = data.redirectUrl;
+      }
+    } catch {
       setError('Something went wrong. Please try again.');
       setLoading(false);
     }
   };
+
+  // Step 2: Organization name form (after Google auth)
+  const isOrgStep = step === 'org' && googleData;
 
   return (
     <div style={{
@@ -136,446 +158,284 @@ export default function RegisterPage() {
         backgroundColor: '#ffffff',
         padding: '2rem 3rem',
         display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        overflowY: 'auto'
+        flexDirection: 'column',
+        position: 'relative'
       }}
       className="right-panel">
-        <div style={{ maxWidth: '420px', width: '100%' }}>
 
-          {/* Header */}
-          <div style={{ marginBottom: '1.5rem' }}>
-            <h2 style={{
-              fontSize: '28px',
-              fontWeight: '600',
+        {/* Login link top right */}
+        <div style={{
+          display: 'flex',
+          justifyContent: 'flex-end',
+          marginBottom: '2rem'
+        }}>
+          <Link
+            href="/login"
+            style={{
               color: 'rgba(0, 0, 0, 0.87)',
-              marginBottom: '0.5rem',
-              margin: 0
-            }}>
-              Create your admin account
-            </h2>
-            <p style={{
-              fontSize: '15px',
-              color: 'rgba(0, 0, 0, 0.5)',
-              fontWeight: '300',
-              margin: '0.25rem 0 0 0'
-            }}>
-              Set up your organization on Schedule Builder
-            </p>
-          </div>
+              fontSize: '0.9375rem',
+              textDecoration: 'none',
+              fontWeight: '400'
+            }}
+            onMouseOver={(e) => e.currentTarget.style.color = '#14b8a6'}
+            onMouseOut={(e) => e.currentTarget.style.color = 'rgba(0, 0, 0, 0.87)'}
+          >
+            Login
+          </Link>
+        </div>
 
-          {error && (
-            <div style={{
-              padding: '1rem 1.25rem',
-              backgroundColor: 'rgba(239, 68, 68, 0.1)',
-              border: '1px solid rgba(239, 68, 68, 0.3)',
-              borderRadius: '8px',
-              marginBottom: '1.5rem'
-            }}>
-              <p style={{
-                color: '#dc2626',
-                fontSize: '0.9375rem',
-                margin: 0,
-                fontWeight: '400'
-              }}>
-                {error}
-              </p>
-            </div>
-          )}
+        {/* Centered content */}
+        <div style={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center'
+        }}>
+          <div style={{ maxWidth: '420px', width: '100%' }}>
 
-          {success ? (
-            <div style={{ textAlign: 'center' }}>
-              <div style={{
-                width: '64px',
-                height: '64px',
-                margin: '0 auto 1.5rem auto',
-                backgroundColor: 'rgba(20, 184, 166, 0.15)',
-                borderRadius: '50%',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center'
-              }}>
-                <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#14b8a6" strokeWidth="2">
-                  <path d="M20 6L9 17l-5-5" />
-                </svg>
-              </div>
-
-              <h2 style={{
-                fontSize: '1.5rem',
-                fontWeight: '400',
-                color: 'rgba(0, 0, 0, 0.87)',
-                marginBottom: '0.75rem',
-                fontFamily: 'Georgia, serif'
-              }}>
-                Account created successfully
-              </h2>
-
-              <p style={{
-                color: 'rgba(0, 0, 0, 0.6)',
-                fontSize: '0.9375rem',
-                margin: '0 0 2rem 0',
-                lineHeight: '1.6',
-                fontWeight: '400'
-              }}>
-                You can now login with your email and password.
-              </p>
-
-              <Link
-                href="/login"
-                style={{
-                  display: 'inline-block',
-                  padding: '0.875rem 2rem',
-                  backgroundColor: '#14b8a6',
-                  color: '#ffffff',
-                  borderRadius: '8px',
-                  fontSize: '0.9375rem',
-                  fontWeight: '500',
-                  textDecoration: 'none',
-                  transition: 'all 0.2s'
-                }}
-                onMouseOver={(e) => e.currentTarget.style.backgroundColor = '#0d9488'}
-                onMouseOut={(e) => e.currentTarget.style.backgroundColor = '#14b8a6'}
-              >
-                Continue to Login
-              </Link>
-            </div>
-          ) : (
-            <form onSubmit={handleSubmit}>
-              {/* Info Banner */}
-              <div style={{
-                padding: '0.75rem 1rem',
-                backgroundColor: 'rgba(20, 184, 166, 0.05)',
-                border: '1px solid rgba(20, 184, 166, 0.2)',
-                borderRadius: '8px',
-                marginBottom: '1.25rem'
-              }}>
-                <p style={{
-                  color: 'rgba(0, 0, 0, 0.6)',
-                  fontSize: '0.8125rem',
-                  margin: 0,
-                  lineHeight: '1.5',
-                  fontWeight: '400'
-                }}>
-                  Create a primary admin account for your organization
-                </p>
-              </div>
-
-              {/* Form Fields */}
-              <div style={{ marginBottom: '1rem' }}>
-                <label style={{
-                  display: 'block',
-                  fontSize: '14px',
-                  fontWeight: '500',
-                  color: 'rgba(0, 0, 0, 0.65)',
-                  marginBottom: '0.5rem'
-                }}>
-                  Your Name
-                </label>
-                <input
-                  type="text"
-                  name="name"
-                  value={formData.name}
-                  onChange={handleChange}
-                  required
-                  style={{
-                    width: '100%',
-                    padding: '0.875rem 1rem',
-                    backgroundColor: '#ffffff',
-                    border: '1px solid rgba(0, 0, 0, 0.2)',
-                    borderRadius: '8px',
-                    fontSize: '0.9375rem',
+            {!isOrgStep ? (
+              <>
+                {/* Step 1: Google Sign Up */}
+                <div style={{ marginBottom: '2rem', textAlign: 'center' }}>
+                  <h2 style={{
+                    fontSize: '28px',
+                    fontWeight: '600',
                     color: 'rgba(0, 0, 0, 0.87)',
-                    outline: 'none',
-                    fontWeight: '400',
-                    transition: 'all 0.2s',
-                    boxSizing: 'border-box'
-                  }}
-                  onFocus={(e) => {
-                    e.currentTarget.style.borderColor = '#14b8a6';
-                    e.currentTarget.style.boxShadow = '0 0 0 3px rgba(20, 184, 166, 0.1)';
-                  }}
-                  onBlur={(e) => {
-                    e.currentTarget.style.borderColor = 'rgba(0, 0, 0, 0.2)';
-                    e.currentTarget.style.boxShadow = 'none';
-                  }}
-                />
-              </div>
-
-              <div style={{ marginBottom: '1rem' }}>
-                <label style={{
-                  display: 'block',
-                  fontSize: '14px',
-                  fontWeight: '500',
-                  color: 'rgba(0, 0, 0, 0.65)',
-                  marginBottom: '0.5rem'
-                }}>
-                  Organization Name
-                </label>
-                <input
-                  type="text"
-                  name="organizationName"
-                  value={formData.organizationName}
-                  onChange={handleChange}
-                  required
-                  placeholder="e.g., ABC University"
-                  style={{
-                    width: '100%',
-                    padding: '0.875rem 1rem',
-                    backgroundColor: '#ffffff',
-                    border: '1px solid rgba(0, 0, 0, 0.2)',
-                    borderRadius: '8px',
-                    fontSize: '0.9375rem',
-                    color: 'rgba(0, 0, 0, 0.87)',
-                    outline: 'none',
-                    fontWeight: '400',
-                    transition: 'all 0.2s',
-                    boxSizing: 'border-box'
-                  }}
-                  onFocus={(e) => {
-                    e.currentTarget.style.borderColor = '#14b8a6';
-                    e.currentTarget.style.boxShadow = '0 0 0 3px rgba(20, 184, 166, 0.1)';
-                  }}
-                  onBlur={(e) => {
-                    e.currentTarget.style.borderColor = 'rgba(0, 0, 0, 0.2)';
-                    e.currentTarget.style.boxShadow = 'none';
-                  }}
-                />
-              </div>
-
-              <div style={{ marginBottom: '1rem' }}>
-                <label style={{
-                  display: 'block',
-                  fontSize: '14px',
-                  fontWeight: '500',
-                  color: 'rgba(0, 0, 0, 0.65)',
-                  marginBottom: '0.5rem'
-                }}>
-                  Email Address
-                </label>
-                <input
-                  type="email"
-                  name="email"
-                  value={formData.email}
-                  onChange={handleChange}
-                  required
-                  style={{
-                    width: '100%',
-                    padding: '0.875rem 1rem',
-                    backgroundColor: '#ffffff',
-                    border: '1px solid rgba(0, 0, 0, 0.2)',
-                    borderRadius: '8px',
-                    fontSize: '0.9375rem',
-                    color: 'rgba(0, 0, 0, 0.87)',
-                    outline: 'none',
-                    fontWeight: '400',
-                    transition: 'all 0.2s',
-                    boxSizing: 'border-box'
-                  }}
-                  onFocus={(e) => {
-                    e.currentTarget.style.borderColor = '#14b8a6';
-                    e.currentTarget.style.boxShadow = '0 0 0 3px rgba(20, 184, 166, 0.1)';
-                  }}
-                  onBlur={(e) => {
-                    e.currentTarget.style.borderColor = 'rgba(0, 0, 0, 0.2)';
-                    e.currentTarget.style.boxShadow = 'none';
-                  }}
-                />
-              </div>
-
-              <div style={{ marginBottom: '1rem' }}>
-                <label style={{
-                  display: 'block',
-                  fontSize: '14px',
-                  fontWeight: '500',
-                  color: 'rgba(0, 0, 0, 0.65)',
-                  marginBottom: '0.5rem'
-                }}>
-                  Password
-                </label>
-                <input
-                  type="password"
-                  name="password"
-                  value={formData.password}
-                  onChange={handleChange}
-                  required
-                  minLength="12"
-                  placeholder="Enter password"
-                  style={{
-                    width: '100%',
-                    padding: '0.875rem 1rem',
-                    backgroundColor: '#ffffff',
-                    border: '1px solid rgba(0, 0, 0, 0.2)',
-                    borderRadius: '8px',
-                    fontSize: '0.9375rem',
-                    color: 'rgba(0, 0, 0, 0.87)',
-                    outline: 'none',
-                    fontWeight: '400',
-                    transition: 'all 0.2s',
-                    boxSizing: 'border-box'
-                  }}
-                  onFocus={(e) => {
-                    e.currentTarget.style.borderColor = '#14b8a6';
-                    e.currentTarget.style.boxShadow = '0 0 0 3px rgba(20, 184, 166, 0.1)';
-                  }}
-                  onBlur={(e) => {
-                    e.currentTarget.style.borderColor = 'rgba(0, 0, 0, 0.2)';
-                    e.currentTarget.style.boxShadow = 'none';
-                  }}
-                />
-
-                {/* Password Requirements Display */}
-                <PasswordRequirementsDisplay
-                  password={formData.password}
-                  validation={passwordValidation}
-                  showStrengthBar={true}
-                />
-              </div>
-
-              <div style={{ marginBottom: '2rem' }}>
-                <label style={{
-                  display: 'block',
-                  fontSize: '14px',
-                  fontWeight: '500',
-                  color: 'rgba(0, 0, 0, 0.65)',
-                  marginBottom: '0.5rem'
-                }}>
-                  Confirm Password
-                </label>
-                <input
-                  type="password"
-                  name="confirmPassword"
-                  value={formData.confirmPassword}
-                  onChange={handleChange}
-                  required
-                  minLength="12"
-                  placeholder="Re-enter your password"
-                  style={{
-                    width: '100%',
-                    padding: '0.875rem 1rem',
-                    backgroundColor: '#ffffff',
-                    border: '1px solid rgba(0, 0, 0, 0.2)',
-                    borderRadius: '8px',
-                    fontSize: '0.9375rem',
-                    color: 'rgba(0, 0, 0, 0.87)',
-                    outline: 'none',
-                    fontWeight: '400',
-                    transition: 'all 0.2s',
-                    boxSizing: 'border-box'
-                  }}
-                  onFocus={(e) => {
-                    e.currentTarget.style.borderColor = '#14b8a6';
-                    e.currentTarget.style.boxShadow = '0 0 0 3px rgba(20, 184, 166, 0.1)';
-                  }}
-                  onBlur={(e) => {
-                    e.currentTarget.style.borderColor = 'rgba(0, 0, 0, 0.2)';
-                    e.currentTarget.style.boxShadow = 'none';
-                  }}
-                />
-
-                {/* Password Match Indicator */}
-                {formData.confirmPassword && (
-                  <div style={{
-                    marginTop: '0.5rem',
-                    padding: '0.5rem 0.75rem',
-                    backgroundColor: formData.password === formData.confirmPassword
-                      ? 'rgba(16, 185, 129, 0.1)'
-                      : 'rgba(220, 38, 38, 0.1)',
-                    border: `1px solid ${formData.password === formData.confirmPassword
-                      ? 'rgba(16, 185, 129, 0.3)'
-                      : 'rgba(220, 38, 38, 0.3)'}`,
-                    borderRadius: '6px',
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '0.5rem',
-                    transition: 'all 0.2s ease'
+                    margin: 0
                   }}>
-                    <span style={{
-                      fontSize: '0.75rem',
-                      fontWeight: '500',
-                      color: formData.password === formData.confirmPassword
-                        ? '#10b981'
-                        : '#dc2626'
+                    Create an account
+                  </h2>
+                </div>
+
+                {/* Error Message */}
+                {(errorFromUrl || error) && (
+                  <div style={{
+                    padding: '1rem 1.25rem',
+                    backgroundColor: 'rgba(239, 68, 68, 0.1)',
+                    border: '1px solid rgba(239, 68, 68, 0.3)',
+                    borderRadius: '8px',
+                    marginBottom: '1.5rem'
+                  }}>
+                    <p style={{
+                      color: '#dc2626',
+                      fontSize: '0.9375rem',
+                      margin: 0,
+                      fontWeight: '400',
+                      textAlign: 'center'
                     }}>
-                      {formData.password === formData.confirmPassword
-                        ? '✓ Passwords match'
-                        : '✗ Passwords do not match'}
-                    </span>
+                      {errorFromUrl || error}
+                    </p>
                   </div>
                 )}
-              </div>
 
-              {/* Submit Button */}
-              <button
-                type="submit"
-                disabled={loading || !isPasswordValid || formData.password !== formData.confirmPassword}
-                style={{
-                  width: '100%',
-                  padding: '0.875rem 1.5rem',
-                  backgroundColor: (loading || !isPasswordValid || formData.password !== formData.confirmPassword)
-                    ? 'rgba(20, 184, 166, 0.5)'
-                    : '#14b8a6',
-                  color: '#ffffff',
-                  border: 'none',
-                  borderRadius: '8px',
-                  fontSize: '16px',
-                  fontWeight: '500',
-                  cursor: (loading || !isPasswordValid || formData.password !== formData.confirmPassword)
-                    ? 'not-allowed'
-                    : 'pointer',
-                  marginBottom: '1.5rem',
-                  transition: 'all 0.2s',
-                  opacity: (loading || !isPasswordValid || formData.password !== formData.confirmPassword) ? 0.6 : 1
-                }}
-                onMouseOver={(e) => {
-                  if (!loading && isPasswordValid && formData.password === formData.confirmPassword) {
-                    e.currentTarget.style.backgroundColor = '#0d9488';
-                  }
-                }}
-                onMouseOut={(e) => {
-                  if (!loading && isPasswordValid && formData.password === formData.confirmPassword) {
-                    e.currentTarget.style.backgroundColor = '#14b8a6';
-                  }
-                }}
-              >
-                {loading ? 'Creating account...' : 'Create Admin Account'}
-              </button>
-
-              {/* Login Link */}
-              <div style={{ textAlign: 'center' }}>
-                <Link
-                  href="/login"
+                {/* Continue with Google Button */}
+                <button
+                  onClick={handleGoogleSignUp}
                   style={{
-                    color: '#14b8a6',
-                    fontSize: '0.9375rem',
-                    textDecoration: 'none',
-                    fontWeight: '400'
+                    width: '100%',
+                    padding: '0.875rem 1.5rem',
+                    backgroundColor: '#ffffff',
+                    color: 'rgba(0, 0, 0, 0.87)',
+                    border: '1px solid rgba(0, 0, 0, 0.2)',
+                    borderRadius: '8px',
+                    fontSize: '16px',
+                    fontWeight: '500',
+                    cursor: 'pointer',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: '0.75rem',
+                    transition: 'all 0.2s',
+                    marginBottom: '1.5rem'
                   }}
-                  onMouseOver={(e) => e.currentTarget.style.textDecoration = 'underline'}
-                  onMouseOut={(e) => e.currentTarget.style.textDecoration = 'none'}
+                  onMouseOver={(e) => {
+                    e.currentTarget.style.backgroundColor = 'rgba(0, 0, 0, 0.02)';
+                    e.currentTarget.style.borderColor = 'rgba(0, 0, 0, 0.3)';
+                  }}
+                  onMouseOut={(e) => {
+                    e.currentTarget.style.backgroundColor = '#ffffff';
+                    e.currentTarget.style.borderColor = 'rgba(0, 0, 0, 0.2)';
+                  }}
                 >
-                  Already have an account? Login
-                </Link>
-              </div>
-            </form>
-          )}
+                  {/* Google Icon */}
+                  <svg width="20" height="20" viewBox="0 0 24 24">
+                    <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4"/>
+                    <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+                    <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
+                    <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+                  </svg>
+                  Continue with Google
+                </button>
 
-          {/* Footer */}
-          <div style={{ marginTop: '2rem', textAlign: 'center' }}>
-            <Link
-              href="/"
-              style={{
-                color: 'rgba(0, 0, 0, 0.4)',
-                fontSize: '0.875rem',
-                textDecoration: 'none',
-                fontWeight: '400'
-              }}
-              onMouseOver={(e) => e.currentTarget.style.color = 'rgba(0, 0, 0, 0.6)'}
-              onMouseOut={(e) => e.currentTarget.style.color = 'rgba(0, 0, 0, 0.4)'}
-            >
-              Back to home
-            </Link>
+                {/* Terms of Service */}
+                <p style={{
+                  fontSize: '0.8125rem',
+                  color: 'rgba(0, 0, 0, 0.45)',
+                  textAlign: 'center',
+                  lineHeight: '1.6',
+                  margin: 0
+                }}>
+                  By clicking continue, you agree to our{' '}
+                  <a
+                    href="https://schedule-builder-docs.vercel.app/legal/terms.html"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{
+                      color: 'rgba(0, 0, 0, 0.6)',
+                      textDecoration: 'underline'
+                    }}
+                  >
+                    Terms of Service
+                  </a>
+                  {' '}and{' '}
+                  <a
+                    href="https://schedule-builder-docs.vercel.app/legal/privacy.html"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{
+                      color: 'rgba(0, 0, 0, 0.6)',
+                      textDecoration: 'underline'
+                    }}
+                  >
+                    Privacy Policy
+                  </a>.
+                </p>
+              </>
+            ) : (
+              <>
+                {/* Step 2: Organization Name */}
+                <div style={{ marginBottom: '1.5rem', textAlign: 'center' }}>
+                  <h2 style={{
+                    fontSize: '28px',
+                    fontWeight: '600',
+                    color: 'rgba(0, 0, 0, 0.87)',
+                    margin: 0,
+                    marginBottom: '0.5rem'
+                  }}>
+                    Set up your organization
+                  </h2>
+                  <p style={{
+                    fontSize: '15px',
+                    color: 'rgba(0, 0, 0, 0.5)',
+                    fontWeight: '300',
+                    margin: 0
+                  }}>
+                    One last step to complete your admin account
+                  </p>
+                </div>
+
+                {/* Error Message */}
+                {error && (
+                  <div style={{
+                    padding: '1rem 1.25rem',
+                    backgroundColor: 'rgba(239, 68, 68, 0.1)',
+                    border: '1px solid rgba(239, 68, 68, 0.3)',
+                    borderRadius: '8px',
+                    marginBottom: '1.5rem'
+                  }}>
+                    <p style={{
+                      color: '#dc2626',
+                      fontSize: '0.9375rem',
+                      margin: 0,
+                      fontWeight: '400',
+                      textAlign: 'center'
+                    }}>
+                      {error}
+                    </p>
+                  </div>
+                )}
+
+                {/* Google Account Info */}
+                <div style={{
+                  padding: '1rem 1.25rem',
+                  backgroundColor: 'rgba(20, 184, 166, 0.05)',
+                  border: '1px solid rgba(20, 184, 166, 0.2)',
+                  borderRadius: '8px',
+                  marginBottom: '1.5rem'
+                }}>
+                  <p style={{
+                    fontSize: '0.875rem',
+                    color: 'rgba(0, 0, 0, 0.6)',
+                    margin: 0,
+                    lineHeight: '1.6'
+                  }}>
+                    Signing up as <strong style={{ color: 'rgba(0, 0, 0, 0.87)' }}>{googleData.name}</strong>
+                    <br />
+                    <span style={{ color: 'rgba(0, 0, 0, 0.45)' }}>{googleData.email}</span>
+                  </p>
+                </div>
+
+                <form onSubmit={handleSubmitOrg}>
+                  <div style={{ marginBottom: '2rem' }}>
+                    <label style={{
+                      display: 'block',
+                      fontSize: '14px',
+                      fontWeight: '500',
+                      color: 'rgba(0, 0, 0, 0.65)',
+                      marginBottom: '0.5rem'
+                    }}>
+                      Organization Name
+                    </label>
+                    <input
+                      type="text"
+                      value={organizationName}
+                      onChange={(e) => setOrganizationName(e.target.value)}
+                      required
+                      disabled={loading}
+                      placeholder="e.g., ABC University"
+                      style={{
+                        width: '100%',
+                        padding: '0.875rem 1rem',
+                        backgroundColor: '#ffffff',
+                        border: '1px solid rgba(0, 0, 0, 0.2)',
+                        borderRadius: '8px',
+                        fontSize: '0.9375rem',
+                        color: 'rgba(0, 0, 0, 0.87)',
+                        outline: 'none',
+                        fontWeight: '400',
+                        transition: 'all 0.2s',
+                        boxSizing: 'border-box'
+                      }}
+                      onFocus={(e) => {
+                        e.currentTarget.style.borderColor = '#14b8a6';
+                        e.currentTarget.style.boxShadow = '0 0 0 3px rgba(20, 184, 166, 0.1)';
+                      }}
+                      onBlur={(e) => {
+                        e.currentTarget.style.borderColor = 'rgba(0, 0, 0, 0.2)';
+                        e.currentTarget.style.boxShadow = 'none';
+                      }}
+                    />
+                  </div>
+
+                  <button
+                    type="submit"
+                    disabled={loading || !organizationName.trim()}
+                    style={{
+                      width: '100%',
+                      padding: '0.875rem 1.5rem',
+                      backgroundColor: (loading || !organizationName.trim()) ? 'rgba(20, 184, 166, 0.5)' : '#14b8a6',
+                      color: '#ffffff',
+                      border: 'none',
+                      borderRadius: '8px',
+                      fontSize: '16px',
+                      fontWeight: '500',
+                      cursor: (loading || !organizationName.trim()) ? 'not-allowed' : 'pointer',
+                      transition: 'all 0.2s'
+                    }}
+                    onMouseOver={(e) => {
+                      if (!loading && organizationName.trim()) e.currentTarget.style.backgroundColor = '#0d9488';
+                    }}
+                    onMouseOut={(e) => {
+                      if (!loading && organizationName.trim()) e.currentTarget.style.backgroundColor = '#14b8a6';
+                    }}
+                  >
+                    {loading ? 'Creating account...' : 'Complete Registration'}
+                  </button>
+                </form>
+              </>
+            )}
+
           </div>
-
         </div>
       </div>
 
@@ -591,5 +451,29 @@ export default function RegisterPage() {
         }
       `}</style>
     </div>
+  );
+}
+
+export default function RegisterPage() {
+  return (
+    <Suspense fallback={
+      <div style={{
+        minHeight: '100vh',
+        backgroundColor: '#ffffff',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center'
+      }}>
+        <div style={{
+          color: 'rgba(0, 0, 0, 0.6)',
+          fontSize: '1rem',
+          fontWeight: '400'
+        }}>
+          Loading...
+        </div>
+      </div>
+    }>
+      <RegisterForm />
+    </Suspense>
   );
 }

--- a/lib/db/models/User.js
+++ b/lib/db/models/User.js
@@ -13,6 +13,11 @@ const UserSchema = new mongoose.Schema({
     required: false, // Optional - some users may use passwordless login
     select: false,   // Don't include password in queries by default
   },
+  googleId: {
+    type: String,
+    unique: true,
+    sparse: true, // Allows multiple null values (not all users will have googleId)
+  },
   secondaryEmail: {
     type: String,
     lowercase: true,


### PR DESCRIPTION
## Summary
- Replace all email/password login and registration forms with "Continue with Google" OAuth flow
- Login page shows only a Google sign-in button for all users
- Register page shows Google button, then collects organization name in a second step for primary admins
- Add `googleId` field to User model for linking Google accounts
- Add `@gmail.com` email validation when admins add students or secondary admins
- Create backend OAuth routes with CSRF protection

## Test plan
- [ ] Click "Continue with Google" on `/login` — redirects to Google sign-in
- [ ] Existing user logs in successfully after Google auth
- [ ] Non-existent user sees "No account found" error
- [ ] `/register` flow: Google auth → org name form → admin account created
- [ ] Non-Gmail accounts rejected with error message
- [ ] Admin adding non-Gmail user sees validation error
- [ ] OAuth cancellation redirects back with error

Closes #68, Closes #22