### PR TITLE
feat: replace email/password auth with Google OAuth sign-in

### DIFF
--- a/app/api/auth/google/callback/route.js
+++ b/app/api/auth/google/callback/route.js
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { createSession, setSessionCookie } from '../../../../../lib/auth/session';
+import { createSession } from '../../../../../lib/auth/session';
 import dbConnect from '../../../../../lib/db/connect';
 import User from '../../../../../lib/db/models/User';
 
@@ -135,11 +135,20 @@ export async function GET(request) {
 
       // Create session
       const session = await createSession(user._id.toString());
-      await setSessionCookie(session.token, session.expiresAt);
 
       // Redirect based on role
       const redirectUrl = user.role === 'admin' ? '/admin' : '/dashboard';
       const response = NextResponse.redirect(new URL(redirectUrl, request.url));
+
+      // Set session cookie directly on the redirect response
+      response.cookies.set('session_token', session.token, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax',
+        expires: session.expiresAt,
+        path: '/',
+        domain: process.env.COOKIE_DOMAIN || undefined,
+      });
       response.cookies.delete('google_oauth_state');
       return response;
     }

--- a/lib/auth/session.js
+++ b/lib/auth/session.js
@@ -52,8 +52,8 @@ export async function setSessionCookie(token, expiresAt) {
     sameSite: 'lax',
     expires: expiresAt,
     path: '/',
-    // Set domain for cross-subdomain cookie sharing (forum.schedule-builder.xyz)
-    domain: process.env.NODE_ENV === 'production' ? '.schedule-builder.xyz' : undefined,
+    // Set domain for cross-subdomain cookie sharing if using custom domain
+    domain: process.env.COOKIE_DOMAIN || undefined,
   });
 }
 


### PR DESCRIPTION
## Summary
- Replace all email/password login and registration forms with "Continue with Google" OAuth flow
- Login page shows only a Google sign-in button for all users
- Register page shows Google button, then collects organization name in a second step for primary admins
- Add `googleId` field to User model for linking Google accounts
- Add `@gmail.com` email validation when admins add students or secondary admins
- Create backend OAuth routes with CSRF protection
- Fix session cookie domain for Vercel deployment

## Test plan
- [ ] Click "Continue with Google" on `/login` — redirects to Google sign-in
- [ ] Existing user logs in successfully after Google auth
- [ ] Non-existent user sees "No account found" error
- [ ] `/register` flow: Google auth → org name form → admin account created
- [ ] Non-Gmail accounts rejected with error message
- [ ] Admin adding non-Gmail user sees validation error
- [ ] OAuth cancellation redirects back with error

Closes #68, Closes #22
